### PR TITLE
fix(user): fetching username and email to use with the commit

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,10 @@ async function run() {
     const octokit = github.getOctokit(token);
 
     const pr = github.context.payload.pull_request;
-    const prAuthor = pr.user;
+    const username = pr.user.login;
+    const { data: user } = await octokit.rest.users.getByUsername({ username });
+    const email = user.email || username+"@users.noreply.github.com";
+    const prAuthor = { "name": user.name || username, "email": email };
 
     const prTargetBranch = pr.base.ref.replace('refs/heads/', '');
 


### PR DESCRIPTION
fix the username and email to use with the commit
TODO: After merging and creating tag for it, the tag needs to be set on **cherry-pick action**

### BEFORE:
![Screenshot 2025-01-18 at 15 31 35](https://github.com/user-attachments/assets/4307f23b-ad05-451b-875a-6fa331cdf9ee)
![Screenshot 2025-01-18 at 15 32 38](https://github.com/user-attachments/assets/d49c10c3-768d-4ea5-a072-f03aad82b827)

### AFTER:
![Screenshot 2025-01-18 at 15 29 38](https://github.com/user-attachments/assets/3c96aca8-2f66-485b-9e65-0a557c179b7b)

![Screenshot 2025-01-18 at 15 32 10](https://github.com/user-attachments/assets/8cb8b450-5165-4472-9e51-7a292cbb0e2c)

